### PR TITLE
remove direct import for powerbi-models, update to 2.3.1

### DIFF
--- a/addon/components/powerbi-report.js
+++ b/addon/components/powerbi-report.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/powerbi-report';
-import models from 'powerbi-models';
+import pbi from 'powerbi-client';
 
 export default Ember.Component.extend({
   classNames: ['powerbi-frame'],
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   name: null,
   reportId: null,
   options: null,
-  tokenType: models.TokenType.Embed,
+  tokenType: pbi.models.TokenType.Embed,
 
   didRender() {
     this._super(...arguments);

--- a/index.js
+++ b/index.js
@@ -11,10 +11,8 @@ module.exports = {
 	included: function(app) {
 		this._super.included.apply(this, arguments);
 
-		app.import('vendor/powerbi-client/dist/powerbi.min.js');
-		app.import('vendor/powerbi-models.min.js');
+		app.import('vendor/powerbi-client/dist/powerbi.js');
 		app.import('vendor/shims/powerbi.js');
 		app.import('vendor/shims/powerbi-client.js');
-		app.import('vendor/shims/powerbi-models.js');
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-powerbi",
-  "version": "1.0.0-beta.4-ab-1.0.0",
+  "version": "1.0.0-beta.4-ab-1.0.1",
   "description": "A set of Ember components to embed Power BI components into Ember applications.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
- removed direct import to powerbi-models (it is included in powerbi-client)
- updated base component to use powerbi-client instead of powerbi-models
- change import to non-minified to avoid double minify
- remove shim for powerbi-models
- @todo: there is still a sourcemap error but it seems non-breaking